### PR TITLE
Added launch file for spawning multiple rbcar(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Edited to launch multiple rbcars on gazebo. 
+
+Dependencies of the original packages are: ackermann-msgs, joy, gazebo-ros-control, robotnik-sensors
+
 # rbcar_sim
 Robotnik Car Simulation Packages
 

--- a/rbcar_control/config/rbcar_control.yaml
+++ b/rbcar_control/config/rbcar_control.yaml
@@ -1,4 +1,4 @@
-rbcar:
+
   left_front_shock_controller:
 #    type: velocity_controllers/JointVelocityController
     type: effort_controllers/JointEffortController

--- a/rbcar_control/launch/rbcar_control.launch
+++ b/rbcar_control/launch/rbcar_control.launch
@@ -3,7 +3,7 @@
 
   <!-- load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" ns="/rbcar" args="--shutdown-time 1 --namespace=/rbcar
+    output="screen" args="--shutdown-time 1 
 					  left_front_shock_controller
 					  left_steering_joint_controller
 					  left_front_axle_controller
@@ -24,14 +24,14 @@
   <!-- convert joint states to TF transforms for rviz, etc -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"
     respawn="false" output="screen">
-    <remap from="/joint_states" to="/rbcar/joint_states" />
+    <!-- <remap from="/joint_states" to="/rbcar/joint_states" /> -->
   </node>
   
   <node pkg="twist_mux" type="twist_mux" name="twist_mux">
     <rosparam command="load" file="$(find rbcar_control)/config/twist_mux.yaml" />    
     <remap from="cmd_vel_out" to="/cmd_vel_out" />
   </node>
-  
+
 
 </launch>
 

--- a/rbcar_gazebo/launch/multi_car.launch
+++ b/rbcar_gazebo/launch/multi_car.launch
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="debug" default="false"/>
+    <arg name="gui" default="true"/>
+
+
+    <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="world_name" value="$(find rbcar_gazebo)/worlds/rbcar.world"/>
+        <arg name="debug" value="$(arg debug)" />
+        <arg name="gui" value="$(arg gui)" />
+        <arg name="paused" value="false"/>
+        <arg name="use_sim_time" value="true"/>
+        <arg name="headless" value="false"/>
+    </include>
+
+    <!-- Load the URDF into the ROS Parameter Server -->
+    <param name="robot_description"
+           command="$(find xacro)/xacro '$(find rbcar_description)/robots/rbcar.urdf.xacro' --inorder" />
+
+    <group ns="robot1">
+
+        <include file="$(find rbcar_gazebo)/launch/single_car_spawn.launch">
+            <arg name="init_pose" value="-x 5 -y 1 -z 0 -Y -3.1" />
+            <arg name="robot_name"  value="Robot1" />
+        </include>
+
+    </group>
+
+    <group ns="robot2">
+
+        <include file="$(find rbcar_gazebo)/launch/single_car_spawn.launch">
+            <arg name="init_pose" value="-x 5 -y 6 -z 0 -Y -3.1" />
+            <arg name="robot_name"  value="Robot2" />
+        </include>
+
+    </group>
+
+
+
+
+
+</launch>

--- a/rbcar_gazebo/launch/rbcar.launch
+++ b/rbcar_gazebo/launch/rbcar.launch
@@ -35,6 +35,6 @@
          
   <!-- Call a python script to the run a service call to gazebo_ros to spawn a URDF robot -->
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
-        args="-urdf -model rbcar -param robot_description -z 1"/>
+        args="-urdf -model rbcar -param /robot_description -z 1"/>
 
 </launch>

--- a/rbcar_gazebo/launch/single_car_spawn.launch
+++ b/rbcar_gazebo/launch/single_car_spawn.launch
@@ -1,0 +1,13 @@
+<launch>
+
+    <arg name="init_pose"/>
+    <arg name="robot_name"/>
+
+    <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
+          args="$(arg init_pose) -urdf -param /robot_description -model $(arg robot_name)"/>
+
+    <include file="$(find rbcar_control)/launch/rbcar_control.launch" />
+
+    <include file="$(find rbcar_robot_control)/launch/rbcar_robot_control.launch"/>
+
+</launch>

--- a/rbcar_robot_control/launch/rbcar_robot_control.launch
+++ b/rbcar_robot_control/launch/rbcar_robot_control.launch
@@ -4,7 +4,7 @@
   <arg name="publish_tf" default="true"/>
 
   <node name="rbcar_robot_control" pkg="rbcar_robot_control" type="rbcar_robot_control_node" output="screen">
-	<remap from="joint_states" to="rbcar/joint_states"/>
+	<!-- <remap from="joint_states" to="rbcar/joint_states"/> -->
 	<param name="model" value="rbcar"/>
 	<param name="publish_odom_tf" value="$(arg publish_tf)"/>
   </node> 

--- a/rbcar_robot_control/src/rbcar_robot_control.cpp
+++ b/rbcar_robot_control/src/rbcar_robot_control.cpp
@@ -206,10 +206,10 @@ RbcarControllerClass(ros::NodeHandle h) : diagnostic_(),
   // Ackermann configuration - traction - topics
 
 
-  private_node_handle_.param<std::string>("frw_vel_topic", frw_vel_topic_, "rbcar/right_front_axle_controller/command");
-  private_node_handle_.param<std::string>("flw_vel_topic", flw_vel_topic_, "rbcar/left_front_axle_controller/command");
-  private_node_handle_.param<std::string>("blw_vel_topic", blw_vel_topic_, "rbcar/left_rear_axle_controller/command");
-  private_node_handle_.param<std::string>("brw_vel_topic", brw_vel_topic_, "rbcar/right_rear_axle_controller/command");
+  private_node_handle_.param<std::string>("frw_vel_topic", frw_vel_topic_, "right_front_axle_controller/command");
+  private_node_handle_.param<std::string>("flw_vel_topic", flw_vel_topic_, "left_front_axle_controller/command");
+  private_node_handle_.param<std::string>("blw_vel_topic", blw_vel_topic_, "left_rear_axle_controller/command");
+  private_node_handle_.param<std::string>("brw_vel_topic", brw_vel_topic_, "right_rear_axle_controller/command");
 
   // Ackermann configuration - traction - joint names 
   private_node_handle_.param<std::string>("joint_front_right_wheel", joint_front_right_wheel, "right_front_axle");
@@ -218,8 +218,8 @@ RbcarControllerClass(ros::NodeHandle h) : diagnostic_(),
   private_node_handle_.param<std::string>("joint_back_right_wheel", joint_back_right_wheel, "right_rear_axle");
 
   // Ackermann configuration - direction - topics
-  private_node_handle_.param<std::string>("frw_pos_topic", frw_pos_topic_, "rbcar/right_steering_joint_controller/command");
-  private_node_handle_.param<std::string>("flw_pos_topic", flw_pos_topic_, "rbcar/left_steering_joint_controller/command");
+  private_node_handle_.param<std::string>("frw_pos_topic", frw_pos_topic_, "right_steering_joint_controller/command");
+  private_node_handle_.param<std::string>("flw_pos_topic", flw_pos_topic_, "left_steering_joint_controller/command");
 
   private_node_handle_.param<std::string>("joint_front_right_steer", joint_front_right_steer, "right_steering_joint"); 
   private_node_handle_.param<std::string>("joint_front_left_steer", joint_front_left_steer, "left_steering_joint");


### PR DESCRIPTION
Apart from adding the launch file I have also commented out a few lines which are related to namespaces which makes spawning multiple rbcar(s) possible. This does not affect the existing launch files. 
Related to [PR #9](https://github.com/RobotnikAutomation/rbcar_common/pull/9) in rbcar_common